### PR TITLE
Get rid of old .env.development and use defaults in settings. Secrets…

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,0 @@
-MONGO_USER=admin
-MONGO_PASSWORD=admin_password
-MONGO_DB=nlpland
-MONGO_HOST=127.0.0.1
-AUTH_BACKEND_URL="http://127.0.0.1/api/{version}"
-JWT_SECRET="super_secret_secret"

--- a/cs_insights_prediction_endpoint/utils/settings.py
+++ b/cs_insights_prediction_endpoint/utils/settings.py
@@ -19,12 +19,12 @@ class Settings(BaseSettings):
     jwt_sign_alg: str = "HS256"
     jwt_token_expiration_minutes: int = 30
 
-    jwt_secret: SecretStr
-    mongo_user: SecretStr
-    mongo_password: SecretStr
-    mongo_db: str
-    mongo_host: str
-    auth_backend_url: str
+    jwt_secret: SecretStr = SecretStr("super_secret_secret")
+    mongo_user: SecretStr = SecretStr("admin")
+    mongo_password: SecretStr = SecretStr("admin_user")
+    mongo_db: str = "nlpland"
+    mongo_host: str = "127.0.0.1"
+    auth_backend_url: str = "http://127.0.0.1/api/{version}"
 
     class Config:
         """Configuration for settings"""


### PR DESCRIPTION
… ans envs in production will still have priority.

From the docs https://pydantic-docs.helpmanual.io/usage/settings/#field-value-priority

In the case where a value is specified for the same Settings field in multiple ways, the selected value is determined as follows (in descending order of priority):

1. Arguments passed to the Settings class initialiser.
2. Environment variables.
2. Variables loaded from a dotenv (.env) file.
3. Variables loaded from the secrets directory.
4. The default field values for the Settings model.